### PR TITLE
Corrected PI code for Capital FM

### DIFF
--- a/conf/radio_stations.xml
+++ b/conf/radio_stations.xml
@@ -69,7 +69,7 @@
         <name>Capital FM</name>
         <broadcast_protocol>fm</broadcast_protocol>
         <ecc>e1</ecc>
-        <pi>c586</pi>
+        <pi>c479</pi>
         <freq>09580</freq>
     </radio_station>
 


### PR DESCRIPTION
I was getting a DNS failure.

So I changed to the PI code listed here:
https://radiodns.org/developers/testing-tools/
