### PR TITLE
Upgrade to wxPython version 4.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ pip install -r requirements.txt
 On Mac, you can use pip to install the required packages:
 
 ```bash
-pip install -r requirements.txt
+pip3 install -r requirements.txt
 ```
 
 # Running RadioVisDemo

--- a/lib/main_frame.py
+++ b/lib/main_frame.py
@@ -462,7 +462,7 @@ class MainFrame(wx.Frame):
         Set the current row in a wx.FlexGridSizer object as growable.
         """
         rows, cols = sizer.CalcRowsCols()
-        sizer.AddGrowableRow(rows - 1)
+        sizer.AddGrowableRow(int(rows) - 1)
 
     def set_radio_stations(self, radio_stations):
         self._radio_stations = radio_stations

--- a/radiovis_demo.py
+++ b/radiovis_demo.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright 2009-2011 British Broadcasting Corporation
 #
@@ -93,8 +93,8 @@ def init_logging():
 
 
 if __name__ == '__main__':
-    thread = threading.currentThread()
-    thread.setName("gui") # Allow the GUI thread to be identified.
+    thread = threading.current_thread()
+    thread.name = "gui" # Allow the GUI thread to be identified.
 
     init_logging()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-wxPython~=4.0.0
-dnspython~=1.16.0
+wxPython~=4.2.1
+dnspython~=2.6.1
 nose~=1.3.7
 stomp.py~=4.1.22
 PySocks~=1.7.1


### PR DESCRIPTION
Also switched from `python` to `python3` and `pip` to `pip3` - which is now becoming standard binary names for Python 3